### PR TITLE
Fix buffer conversion for file content

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -40,7 +40,7 @@ async function appendContext(args) {
         }
 
         const fileData = await vscode.workspace.fs.readFile(uri);
-        const fileContent = fileData.toString();
+        const fileContent = Buffer.from(fileData).toString('utf8');
         const trimmedContent = fileContent.replace(/^(\r\n|\n|\r)+|(\r\n|\n|\r)+$/g, '');
         parts.push(`${filePath}: """\n${trimmedContent}\n"""`);
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "contextify",
     "displayName": "Contextify Extractor for LLM",
     "description": "Extract selected files content into one text for LLM context",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "icon": "assets/icon.png",
     "publisher": "nowwweb",
     "extensionKind": [


### PR DESCRIPTION
## Summary
- ensure `fs.readFile` result is converted from `Uint8Array` to string using `Buffer`

## Testing
- `node -c extension.js`
- `npm test` *(fails: Missing script)*