### PR TITLE
Respecte .gitignore lors de l'ajout d'un dossier

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,16 @@ You can then paste this text wherever you need it as context for an LLM.
 
 3. **Result:**
    - The relative paths and contents of the selected files are copied to your clipboard. If you selected a folder, all files inside it (and its subfolders) are included.
+   - Files and folders listed in `.gitignore` are skipped by default when adding a directory.
    - You can now paste this text where you need it.
 
 ## Installation
 - Clone this repository.
 - Open in VS Code.
 - Launch the extension with F5.
+
+## Configuration
+- `contextify.ignoreGitIgnore` *(boolean)* : ignore les chemins listés dans `.gitignore` lors de l'ajout d'un dossier (activé par défaut).
 ## Deploying the Extension for Use Outside the Marketplace
 If you want to share your extension without going through the VS Code Marketplace, you can create a `.vsix` file that other users can install manually.
 

--- a/extension.js
+++ b/extension.js
@@ -10,11 +10,14 @@
  * @param {import('vscode').Uri} uri Dossier de départ
  * @returns {Promise<import('vscode').Uri[]>}
  */
-async function collectFileUris(uri) {
+async function collectFileUris(uri, isIgnored) {
     const vscode = require('vscode');
 
     const stat = await vscode.workspace.fs.stat(uri);
     if (stat.type === vscode.FileType.File) {
+        if (isIgnored && isIgnored(uri)) {
+            return [];
+        }
         return [uri];
     }
 
@@ -23,9 +26,13 @@ async function collectFileUris(uri) {
     for (const [name, type] of entries) {
         const childUri = vscode.Uri.joinPath(uri, name);
         if (type === vscode.FileType.Directory) {
-            files = files.concat(await collectFileUris(childUri));
+            if (!isIgnored || !isIgnored(childUri)) {
+                files = files.concat(await collectFileUris(childUri, isIgnored));
+            }
         } else if (type === vscode.FileType.File) {
-            files.push(childUri);
+            if (!isIgnored || !isIgnored(childUri)) {
+                files.push(childUri);
+            }
         }
     }
     return files;
@@ -39,6 +46,7 @@ async function collectFileUris(uri) {
 async function appendContext(args) {
     const vscode = require('vscode');
     const path = require('path');
+    const ignore = require('ignore');
 
     if (!args) {
         const editor = vscode.window.activeTextEditor;
@@ -51,9 +59,37 @@ async function appendContext(args) {
 
     const oldContent = await vscode.env.clipboard.readText();
 
+    const config = vscode.workspace.getConfiguration('contextify');
+    const ignoreGit = config.get('ignoreGitIgnore', true);
+    let matchers = [];
+    let isIgnored = null;
+
+    if (ignoreGit) {
+        const folders = vscode.workspace.workspaceFolders || [];
+        for (const folder of folders) {
+            const ig = ignore();
+            try {
+                const data = await vscode.workspace.fs.readFile(vscode.Uri.joinPath(folder.uri, '.gitignore'));
+                ig.add(Buffer.from(data).toString('utf8'));
+            } catch (err) {
+                // pas de .gitignore
+            }
+            matchers.push({ folder, ig });
+        }
+        isIgnored = (uri) => {
+            for (const { folder, ig } of matchers) {
+                const rel = path.relative(folder.uri.fsPath, uri.fsPath);
+                if (!rel.startsWith('..') && ig.ignores(rel)) {
+                    return true;
+                }
+            }
+            return false;
+        };
+    }
+
     let parts = [];
     for (const rootUri of uris) {
-        const files = await collectFileUris(rootUri);
+        const files = await collectFileUris(rootUri, isIgnored);
         for (const uri of files) {
             // Récupère le workspace folder correspondant au fichier
             const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "contextify",
     "displayName": "Contextify Extractor for LLM",
     "description": "Extract selected files content into one text for LLM context",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "icon": "assets/icon.png",
     "publisher": "nowwweb",
     "extensionKind": [
@@ -49,10 +49,24 @@
                     "group": "navigation"
                 }
             ]
+        },
+        "configuration": {
+            "type": "object",
+            "title": "Contextify Configuration",
+            "properties": {
+                "contextify.ignoreGitIgnore": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Ignore les fichiers et dossiers d\u00e9finis dans .gitignore lors de l'ajout d'un dossier au contexte."
+                }
+            }
         }
     },
     "repository": {
         "type": "git",
         "url": "https://github.com/Nicolas-nwb/contextify.git"
+    },
+    "dependencies": {
+        "ignore": "^5.2.4"
     }
 }


### PR DESCRIPTION
## Résumé
- ajoute l'option `contextify.ignoreGitIgnore` (activée par défaut)
- ignore les fichiers et dossiers listés dans `.gitignore` lors de l'ajout d'un dossier au contexte
- documente la nouvelle option dans le README

## Tests
- `node -c extension.js`
- `node -e "require('./extension.js');"`