### PR TITLE
Respecte .gitignore lors de l'ajout d'un dossier

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,16 @@ You can then paste this text wherever you need it as context for an LLM.
 
 3. **Result:**
    - The relative paths and contents of the selected files are copied to your clipboard. If you selected a folder, all files inside it (and its subfolders) are included.
+   - Files and folders listed in `.gitignore` are skipped by default when adding a directory.
    - You can now paste this text where you need it.
 
 ## Installation
 - Clone this repository.
 - Open in VS Code.
 - Launch the extension with F5.
+
+## Configuration
+- `contextify.ignoreGitIgnore` *(boolean)* : ignore les chemins listés dans `.gitignore` lors de l'ajout d'un dossier (activé par défaut).
 ## Deploying the Extension for Use Outside the Marketplace
 If you want to share your extension without going through the VS Code Marketplace, you can create a `.vsix` file that other users can install manually.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "contextify",
     "displayName": "Contextify Extractor for LLM",
     "description": "Extract selected files content into one text for LLM context",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "icon": "assets/icon.png",
     "publisher": "nowwweb",
     "extensionKind": [
@@ -49,10 +49,24 @@
                     "group": "navigation"
                 }
             ]
+        },
+        "configuration": {
+            "type": "object",
+            "title": "Contextify Configuration",
+            "properties": {
+                "contextify.ignoreGitIgnore": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Ignore les fichiers et dossiers d\u00e9finis dans .gitignore lors de l'ajout d'un dossier au contexte."
+                }
+            }
         }
     },
     "repository": {
         "type": "git",
         "url": "https://github.com/Nicolas-nwb/contextify.git"
+    },
+    "dependencies": {
+        "ignore": "^5.2.4"
     }
 }


### PR DESCRIPTION
## Résumé
- ajoute l'option `contextify.ignoreGitIgnore` (activée par défaut)
- ignore les fichiers et dossiers listés dans `.gitignore` lors de l'ajout d'un dossier au contexte
- corrige la détection en convertissant les chemins vers un format POSIX
- documente la nouvelle option dans le README

## Tests
- `node -c extension.js`
- `node -e "require('./extension.js');"`
