### PR TITLE
Respect .gitignore only for directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can then paste this text wherever you need it as context for an LLM.
 
 3. **Result:**
    - The relative paths and contents of the selected files are copied to your clipboard. If you selected a folder, all files inside it (and its subfolders) are included.
-   - Files and folders listed in `.gitignore` are skipped by default when adding a directory.
+   - Files and folders listed in `.gitignore` are skipped by default when adding a directory. Individual files are always included even if they appear in `.gitignore`.
    - You can now paste this text where you need it.
 
 ## Installation
@@ -25,7 +25,7 @@ You can then paste this text wherever you need it as context for an LLM.
 - Launch the extension with F5.
 
 ## Configuration
-- `contextify.ignoreGitIgnore` *(boolean)* : ignore les chemins listés dans `.gitignore` lors de l'ajout d'un dossier (activé par défaut).
+- `contextify.ignoreGitIgnore` *(boolean)* : ignore les chemins listés dans `.gitignore` lors de l'ajout d'un dossier (activé par défaut ; n'affecte pas les fichiers individuels).
 ## Deploying the Extension for Use Outside the Marketplace
 If you want to share your extension without going through the VS Code Marketplace, you can create a `.vsix` file that other users can install manually.
 

--- a/extension.js
+++ b/extension.js
@@ -90,7 +90,10 @@ async function appendContext(args) {
 
     let parts = [];
     for (const rootUri of uris) {
-        const files = await collectFileUris(rootUri, isIgnored);
+        const stat = await vscode.workspace.fs.stat(rootUri);
+        // Si la sélection porte sur un fichier individuel, on l'ajoute même s'il est listé dans .gitignore
+        const ignoreForRoot = stat.type === vscode.FileType.Directory ? isIgnored : null;
+        const files = await collectFileUris(rootUri, ignoreForRoot);
         for (const uri of files) {
             // Récupère le workspace folder correspondant au fichier
             const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);


### PR DESCRIPTION
## Notes
- Changement pour ignorer `.gitignore` uniquement lors de la sélection de dossiers
- Mise à jour de la documentation en conséquence

## Testing
- `npm test` *(aucun test défini)*